### PR TITLE
Add support for since, take 2

### DIFF
--- a/annotation/src/main/scala/dataclass/data.scala
+++ b/annotation/src/main/scala/dataclass/data.scala
@@ -4,4 +4,4 @@ import scala.annotation.StaticAnnotation
 
 class data extends StaticAnnotation
 
-class since(version: String = "") extends StaticAnnotation
+class since(version: String = "0.0.0") extends StaticAnnotation

--- a/input/src/main/scala/fix/PersonWithAddress.scala
+++ b/input/src/main/scala/fix/PersonWithAddress.scala
@@ -5,6 +5,6 @@ package fix
 
 import dataclass.{data, since}
 
-@data class Address(street: String, city: String, zip: String)
+@data class Address(@since("1.0") street: String, @since("1.0") city: String = "", @since("1.1") zip: String = "")
 
 @data class PersonWithAddress(name: String, age: Int, @since("1.0") address: Option[Address] = None)

--- a/output/src/main/scala-2.12/fix/PersonWithAddress.scala
+++ b/output/src/main/scala-2.12/fix/PersonWithAddress.scala
@@ -2,7 +2,7 @@ package fix
 
 import dataclass.{data, since}
 
-@data final class Address private (val street: String, val city: String, val zip: String) extends Product with Serializable {
+@data final class Address private (@since("1.0") val street: String, @since("1.0") val city: String, @since("1.1") val zip: String) extends Product with Serializable {
 
 override def equals(obj: Any): Boolean = obj match {
   case c: Address =>
@@ -63,6 +63,8 @@ override def toString = {
 }
 object Address {
 def apply(street: String, city: String, zip: String): Address = new Address(street, city, zip)
+def apply(street: String, city: String): Address = new Address(street, city, "")
+def apply(street: String): Address = new Address(street, "", "")
 }
 
 
@@ -126,6 +128,6 @@ override def toString = {
 
 }
 object PersonWithAddress {
-def apply(name: String, age: Int, @since("1.0") address: Option[Address]): PersonWithAddress = new PersonWithAddress(name, age, address)
+def apply(name: String, age: Int, address: Option[Address]): PersonWithAddress = new PersonWithAddress(name, age, address)
 def apply(name: String, age: Int): PersonWithAddress = new PersonWithAddress(name, age, None)
 }

--- a/output/src/main/scala-2.13/fix/PersonWithAddress.scala
+++ b/output/src/main/scala-2.13/fix/PersonWithAddress.scala
@@ -2,7 +2,7 @@ package fix
 
 import dataclass.{data, since}
 
-@data final class Address private (val street: String, val city: String, val zip: String) extends Product with Serializable {
+@data final class Address private (@since("1.0") val street: String, @since("1.0") val city: String, @since("1.1") val zip: String) extends Product with Serializable {
 
 override def equals(obj: Any): Boolean = obj match {
   case c: Address =>
@@ -63,6 +63,8 @@ override def toString = {
 }
 object Address {
 def apply(street: String, city: String, zip: String): Address = new Address(street, city, zip)
+def apply(street: String, city: String): Address = new Address(street, city, "")
+def apply(street: String): Address = new Address(street, "", "")
 }
 
 
@@ -126,6 +128,6 @@ override def toString = {
 
 }
 object PersonWithAddress {
-def apply(name: String, age: Int, @since("1.0") address: Option[Address]): PersonWithAddress = new PersonWithAddress(name, age, address)
+def apply(name: String, age: Int, address: Option[Address]): PersonWithAddress = new PersonWithAddress(name, age, address)
 def apply(name: String, age: Int): PersonWithAddress = new PersonWithAddress(name, age, None)
 }

--- a/output/src/main/scala-3/fix/PersonWithAddress.scala
+++ b/output/src/main/scala-3/fix/PersonWithAddress.scala
@@ -2,7 +2,7 @@ package fix
 
 import dataclass.{data, since}
 
-@data final class Address private (val street: String, val city: String, val zip: String) extends Product with Serializable {
+@data final class Address private (@since("1.0") val street: String, @since("1.0") val city: String, @since("1.1") val zip: String) extends Product with Serializable {
 
 override def equals(obj: Any): Boolean = obj match {
   case c: Address =>
@@ -63,6 +63,8 @@ override def toString = {
 }
 object Address {
 def apply(street: String, city: String, zip: String): Address = new Address(street, city, zip)
+def apply(street: String, city: String): Address = new Address(street, city, "")
+def apply(street: String): Address = new Address(street, "", "")
 }
 
 
@@ -126,6 +128,6 @@ override def toString = {
 
 }
 object PersonWithAddress {
-def apply(name: String, age: Int, @since("1.0") address: Option[Address]): PersonWithAddress = new PersonWithAddress(name, age, address)
+def apply(name: String, age: Int, address: Option[Address]): PersonWithAddress = new PersonWithAddress(name, age, address)
 def apply(name: String, age: Int): PersonWithAddress = new PersonWithAddress(name, age, None)
 }


### PR DESCRIPTION
Problem
-------
https://github.com/hamnis/dataclass-scalafix/pull/13 added `since`
attribute, but it did not implement the `def apply` generation based on
the version combinations of the since values.

Solution
--------
This implements the `apply` generation.
1. `apply` with all fields are generated.
2. Next a set of since values are calculated, including lack of `since`,
   and additive since increments are generated. For example, given
   none, 1.0, and 1.1, there will be (none), (none, 1.0), and (full).
   `apply`s are generated for (none) and (none, 1.0).
   Newer since fields must have a default value.
3. `apply` without default values are generated if since combination
   hasn't created it.